### PR TITLE
OledWifiInfo: show soft-AP password

### DIFF
--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
     "name": "og3x-oled",
-    "version": "0.2.2",
+    "version": "0.2.3",
     "description": "Add support for SSD1306 OLED to chl33/og3",
     "keywords": "esp32, esp8266, oled",
     "authors": [
@@ -12,7 +12,7 @@
 	}
     ],
     "dependencies": {
-	"chl33/og3": "~0.2.2",
+	"chl33/og3": "~0.2.3",
 	"thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays": "~4.2.0"
     },
     "export": {

--- a/src/oled_wifi_info.cpp
+++ b/src/oled_wifi_info.cpp
@@ -23,8 +23,14 @@ OledWifiInfo::OledWifiInfo(Tasks* tasks) : Module(OledWifiInfo::kName, tasks->mo
       m_oled->addDisplayFn([this]() {
         if (m_wifi->apMode()) {
           char buf[80];
-          snprintf(buf, sizeof(buf), "AP: %s", m_wifi->board().c_str());
+          static bool s_show_password = false;
+          if (s_show_password && m_wifi->ap_password()) {
+            snprintf(buf, sizeof(buf), "PW: %s", m_wifi->ap_password());
+          } else {
+            snprintf(buf, sizeof(buf), "AP: %s", m_wifi->board().c_str());
+          }
           m_oled->display(buf);
+          s_show_password = !s_show_password;
         } else if (m_wifi->wasConnected()) {
           char buf[80];
           snprintf(buf, sizeof(buf), "IP: %s", m_wifi->ipAddress().c_str());


### PR DESCRIPTION
When in soft-AP mode, if AP password is set, then alternate showing the AP ESSID and the password.

This should make it easier to login to the device to connect it to your Wifi network.